### PR TITLE
Fixed gdb-ruby hangs when executing long arguments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,4 +71,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/lib/gdb/gdb.rb
+++ b/lib/gdb/gdb.rb
@@ -15,7 +15,7 @@ module GDB
   #   @return [String]
   #     Returns what gdb displayed after executing this command.
   class GDB
-    # Absolute path to python scripts.
+    # Absolute path to the python scripts.
     SCRIPTS_PATH = File.join(__dir__, 'scripts').freeze
 
     # To launch a gdb instance.
@@ -63,7 +63,7 @@ module GDB
     end
     alias exec execute
 
-    # Set break point.
+    # Set breakpoints.
     #
     # This method does some magic, see examples.
     #
@@ -88,10 +88,10 @@ module GDB
     end
     alias b break
 
-    # Run process.
+    # Run the process.
     #
     # @param [String] args
-    #   Arguments to pass to run command.
+    #   Arguments to pass to +run+ command.
     #
     # @!macro gdb_displayed
     #
@@ -141,7 +141,7 @@ module GDB
     end
     alias code_base text_base
 
-    # Is process running?
+    # Is the process running?
     #
     # Actually judged by if {#pid} returns zero.
     #
@@ -157,7 +157,7 @@ module GDB
     # This method implemented by invoking +python print(gdb.selected_inferior().pid)+.
     #
     # @return [Integer]
-    #   The pid of process. If process is not running, zero is returned.
+    #   The pid of the process. If the process is not running, zero is returned.
     def pid
       @pid = python_p('gdb.selected_inferior().pid').to_i
     end
@@ -174,6 +174,9 @@ module GDB
     end
 
     # Execute +info+ command.
+    #
+    # @param [String] args
+    #   Arguments to pass to +info+ command.
     #
     # @!macro gdb_displayed
     #
@@ -288,7 +291,7 @@ module GDB
     end
 
     # Enter gdb interactive mode.
-    # Gdb will be closed after interaction.
+    # GDB will be closed after interaction.
     #
     # @return [void]
     def interact

--- a/lib/gdb/gdb.rb
+++ b/lib/gdb/gdb.rb
@@ -55,6 +55,9 @@ module GDB
     #   gdb.execute('print $rsi')
     #   #=> "$1 = 0x7fffffffdef8"
     def execute(cmd)
+      # clear tube if not in interactive mode
+      @tube.clear unless interacting?
+
       @tube.puts(cmd)
       @tube.readuntil(@prompt).strip
     end
@@ -102,7 +105,7 @@ module GDB
     #
     # @note
     #   If breakpoints are not set properly and cause gdb hangs,
-    #   this method will hang, too.
+    #   this method hangs as well.
     def run(args = '')
       execute('run ' + args)
     end
@@ -164,7 +167,7 @@ module GDB
     # @!macro gdb_displayed
     #
     # @note
-    #   Beware of this method may block if no breakpoint properly set.
+    #   This method may block the IO if no breakpoints are properly set.
     def continue
       check_alive!
       execute('continue')
@@ -289,6 +292,9 @@ module GDB
     #
     # @return [void]
     def interact
+      return if interacting?
+
+      @interacting = true
       $stdin.raw { @tube.interact(method(:output_hook)) }
       close
     end
@@ -306,6 +312,10 @@ module GDB
     alias quit close
 
     private
+
+    def interacting?
+      defined?(@interacting)
+    end
 
     # Raise {GDBError} if process is not running.
     #

--- a/lib/gdb/tube/tube.rb
+++ b/lib/gdb/tube/tube.rb
@@ -32,9 +32,11 @@ module GDB
         @buffer.get(n)
       end
 
-      # Clear current received buffer.
+      # Clear received data.
       #
-      # @return [void]
+      # @return [String]
+      #   The data cleared.
+      #   An empty string is returned if the buffer is already empty.
       def clear
         @buffer.get
       end

--- a/lib/gdb/tube/tube.rb
+++ b/lib/gdb/tube/tube.rb
@@ -32,6 +32,13 @@ module GDB
         @buffer.get(n)
       end
 
+      # Clear current received buffer.
+      #
+      # @return [void]
+      def clear
+        @buffer.get
+      end
+
       # Receive from +io+ until string +str+ appears.
       #
       # @param [String] str
@@ -63,8 +70,10 @@ module GDB
       #
       # @return [void]
       def puts(data)
+        return data.split("\n").each(&method(:puts)) if data.strip.include?("\n")
+
         @in.puts(data)
-        readuntil(data)
+        readuntil("\n")
       end
 
       # Enter interactive mode.

--- a/spec/gdb_spec.rb
+++ b/spec/gdb_spec.rb
@@ -54,6 +54,11 @@ Starting program: #{File.realpath(@binpath['amd64.pie.elf'])}
     @new_gdb.call('amd64.elf') do |gdb|
       expect(gdb.run('1111').lines[1].strip).to eq '1111'
     end
+
+    # issue#37
+    @new_gdb.call('amd64.elf') do |gdb|
+      expect(gdb.run('A' * 200)).to include('Starting') # only check it not hangs
+    end
   end
 
   it 'register' do


### PR DESCRIPTION
Fixed #37 